### PR TITLE
Add heartbeat support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Change Log
 
-## [Unreleased]
+## 0.2.0(unreleased)
+Add heartbeat suppoert.
+
+## 0.1.0
+Initial release.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ You can use this library with Standard queue but it is almost designed for FIFO 
 [![Clojars Project](https://img.shields.io/clojars/v/toyokumo/gluttony.svg)](https://clojars.org/toyokumo/gluttony)
 
 ## Usage
+### Basis
 Gluttony mainly offer two APIs, `start-consumer` and `stop-consumer`.
 
 `start-consumer` makes a consumer instance.
@@ -55,6 +56,14 @@ if you don't provide it.
 such as the number of worker processes, long polling duration and so on.
 See [API docs](https://cljdoc.org/d/toyokumo/gluttony/CURRENT) for detail.
 
+### Heartbeat
+If you don't know how long it takes to process a message, pass `:hearbeat` and `:heartbeat-timeout` options.
+
+Then Gluttony extends the message visibility per `:hearbeat` seconds to `:heartbeat-timeout` seconds.
+
+See [AWS documents](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/working-with-messages.html) 
+for more detail. 
+
 ## What for?
 There already has been [Squeedo](https://github.com/TheClimateCorporation/squeedo) for the same purpose
 and it provides nice APIs and work as intended. Gluttony use it as reference so much.
@@ -71,10 +80,6 @@ or setting attributes.
 
 ## Test
 You may have to fix `dev-resources/test-config.edn`.
-
-## Future
-
-- Heartbeat support
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -14,4 +14,5 @@
                  [com.cognitect.aws/endpoints "1.1.11.705"]
                  [com.cognitect.aws/sqs "770.2.568.0"]]
   :repl-options {:init-ns gluttony.core}
-  :profiles {:dev {:dependencies [[aero "1.1.4"]]}})
+  :profiles {:dev {:dependencies [[aero "1.1.6"]
+                                  [spootnik/unilog "0.7.24"]]}})

--- a/src/gluttony/core.clj
+++ b/src/gluttony/core.clj
@@ -28,8 +28,8 @@
               body of the sqs message.
               2. a function when it MUST be invoked when the consume success. it takes no arguments.
               3. a function when it MUST be invoked when the consume fail. it takes zero or one
-              argument. the argument decides how long to delay for retrying. 0 to 43200. Maximum: 12
-              hours. when you pass no delay time, retrying as soon as possible.
+              argument. the argument decides how long to delay in seconds for retrying. 0 to 43200.
+              Maximum: 12 hours. when you pass no delay time, retrying as soon as possible.
               like this:
               (defn consume [message respond raise]
                 (let [success? (...your computation uses the message...)]
@@ -55,6 +55,18 @@
     :exceptional-poll-delay-ms - when an Exception is received while polling, receiver wait for the
                                  number of ms until polling again.
                                  default: 10000 (10 seconds).
+    :heartbeat                 - the duration (in seconds) for which the consumer extends message
+                                 visibility if the message is being processed. 1 to 43199.
+                                 default: nil
+                                 If it isn't set, heartbeat doesn't work.
+                                 If it's set, :heartbeat-timeout is required.
+                                 Refer to AWS documents for more detail: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/working-with-messages.html
+    :heartbeat-timeout         - the timeout (in seconds) of heartbeat.
+                                 If your consume function doesn't call respond or raise within heartbeat
+                                 timeout, the consumer doesn't extend message visibility any more.
+                                 2 to 43200.
+                                 default: nil
+                                 :heartbeat-timeout must be longer than :heartbeat.
    Output:
     a instance of gluttony.record.consumer.Consumer"
   ^Consumer [queue-url consume & [opts]]
@@ -82,7 +94,9 @@
                                   :message-channel-size message-channel-size
                                   :receive-limit receive-limit
                                   :long-polling-duration long-polling-duration
-                                  :exceptional-poll-delay-ms exceptional-poll-delay-ms})]
+                                  :exceptional-poll-delay-ms exceptional-poll-delay-ms
+                                  :heartbeat (:heartbeat opts)
+                                  :heartbeat-timeout (:heartbeat-timeout opts)})]
     (p/-start consumer)))
 
 (defn stop-consumer

--- a/test/gluttony/core_test.clj
+++ b/test/gluttony/core_test.clj
@@ -126,7 +126,7 @@
                  (set @collected)))
           (stop-consumer consumer)))
 
-      (testing "Gather every data in order"
+      (testing "Heartbeat work"
         ;; Add test data
         (let [uuid (UUID/randomUUID)]
           (dotimes [i 1]

--- a/test/gluttony/core_test.clj
+++ b/test/gluttony/core_test.clj
@@ -33,7 +33,9 @@
               :message-channel-size (* 20 (max 1 (int (/ num-workers 10))))
               :receive-limit 10
               :long-polling-duration 20
-              :exceptional-poll-delay-ms 10000}
+              :exceptional-poll-delay-ms 10000
+              :heartbeat nil
+              :heartbeat-timeout nil}
              (dissoc consumer :message-chan)))
       (stop-consumer consumer)))
 
@@ -44,7 +46,9 @@
                                     :num-workers 2
                                     :num-receivers 1
                                     :message-channel-size 10
-                                    :receive-limit 5})]
+                                    :receive-limit 5
+                                    :heartbeat 60
+                                    :heartbeat-timeout 300})]
       (is (instance? Consumer consumer))
       (is (= {:queue-url "https://ap..."
               :consume consume
@@ -55,7 +59,9 @@
               :message-channel-size 10
               :receive-limit 5
               :long-polling-duration 20
-              :exceptional-poll-delay-ms 10000}
+              :exceptional-poll-delay-ms 10000
+              :heartbeat 60
+              :heartbeat-timeout 300}
              (dissoc consumer :message-chan)))
       (stop-consumer consumer))))
 
@@ -118,4 +124,35 @@
           (a/<!! (th/wait-chan (* 1000 45) (fn [] (>= (count @collected) 20))))
           (is (= (set (range 1 21))
                  (set @collected)))
+          (stop-consumer consumer)))
+
+      (testing "Gather every data in order"
+        ;; Add test data
+        (let [uuid (UUID/randomUUID)]
+          (dotimes [i 1]
+            (aws/invoke th/client {:op :SendMessage
+                                   :request {:QueueUrl queue-url
+                                             :MessageBody (pr-str {:id (inc i)})
+                                             :MessageDeduplicationId (str uuid ":" i)
+                                             :MessageGroupId (str uuid)}})))
+
+        (let [collected (atom [])
+              consume (fn [message respond _]
+                        (log/info (:body message))
+                        (a/go
+                          ;; wait 3 seconds
+                          (a/<! (a/timeout 3000))
+                          (swap! collected
+                                 conj (:id (edn/read-string (:body message))))
+                          (respond)))
+              consumer (start-consumer queue-url consume
+                                       {:client th/client
+                                        :num-workers 1
+                                        :num-receivers 1
+                                        :long-polling-duration 10
+                                        :heartbeat 1
+                                        :heartbeat-timeout 5})]
+          (a/<!! (th/wait-chan (* 1000 45) (fn [] (>= (count @collected) 1))))
+          (is (= [1]
+                 @collected))
           (stop-consumer consumer))))))

--- a/test/gluttony/core_test.clj
+++ b/test/gluttony/core_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.core.async :as a]
    [clojure.edn :as edn]
-   [clojure.java.io :as io]
    [clojure.test :refer :all]
    [cognitect.aws.client.api :as aws]
    [gluttony.core :refer :all]
@@ -14,6 +13,8 @@
    (java.util UUID)))
 
 (use-fixtures :each th/read-config-fixture th/test-client-fixture)
+
+(use-fixtures :once th/start-logging-fixture)
 
 (deftest start-consumer-test
   (testing "No option"

--- a/test/gluttony/record/consumer_test.clj
+++ b/test/gluttony/record/consumer_test.clj
@@ -127,4 +127,31 @@
                                 :receive-limit 10
                                 :long-polling-duration 20
                                 :exceptional-poll-delay-ms 0}))
-        "exceptional-poll-delay-ms must be a positive value")))
+        "exceptional-poll-delay-ms must be a positive value")
+    (is (thrown? AssertionError
+                 (new-consumer {:queue-url "https://ap..."
+                                :consume (fn [_ _ _])
+                                :client client
+                                :given-client? true
+                                :num-workers 1
+                                :num-receivers 1
+                                :message-channel-size 10
+                                :receive-limit 10
+                                :long-polling-duration 20
+                                :exceptional-poll-delay-ms 0
+                                :heartbeat 60}))
+        "heartbeat is set but heartbeat-timeout isn't set")
+    (is (thrown? AssertionError
+                 (new-consumer {:queue-url "https://ap..."
+                                :consume (fn [_ _ _])
+                                :client client
+                                :given-client? true
+                                :num-workers 1
+                                :num-receivers 1
+                                :message-channel-size 10
+                                :receive-limit 10
+                                :long-polling-duration 20
+                                :exceptional-poll-delay-ms 0
+                                :heartbeat 60
+                                :heartbeat-timeout 10}))
+        "heartbeat is bigger than heartbeat-timeout")))

--- a/test/gluttony/test_helper.clj
+++ b/test/gluttony/test_helper.clj
@@ -4,7 +4,8 @@
    [clojure.core.async :as a]
    [clojure.java.io :as io]
    [clojure.test :refer :all]
-   [cognitect.aws.client.api :as aws]))
+   [cognitect.aws.client.api :as aws]
+   [unilog.config :as unilog]))
 
 (def config nil)
 
@@ -23,6 +24,11 @@
                                 true (aws/client))))
   (f)
   (aws/stop client))
+
+(defn start-logging-fixture [f]
+  (unilog/start-logging! {:level :debug
+                          :overrides {"org.eclipse.jetty" :info}})
+  (f))
 
 (defn wait-chan
   [timeout-msec done?]


### PR DESCRIPTION
Add heartbeat support.

If `heartbeat` and `heartbeat-timeout` option is set, the consumer extend message visibility per `hearbeat` seconds to `heartbeat-timeout` seconds.