### PR TITLE
Bump libraries version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,12 +7,12 @@
                         ["snapshots" :clojars]]
   :plugins [[lein-ancient "0.6.15"]]
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [org.clojure/core.async "0.7.559"]
-                 [org.clojure/tools.logging "0.5.0"]
+                 [org.clojure/core.async "1.1.587"]
+                 [org.clojure/tools.logging "1.0.0"]
                  [camel-snake-kebab "0.4.1"]
-                 [com.cognitect.aws/api "0.8.408"]
-                 [com.cognitect.aws/endpoints "1.1.11.705"]
+                 [com.cognitect.aws/api "0.8.456"]
+                 [com.cognitect.aws/endpoints "1.1.11.753"]
                  [com.cognitect.aws/sqs "770.2.568.0"]]
   :repl-options {:init-ns gluttony.core}
   :profiles {:dev {:dependencies [[aero "1.1.6"]
-                                  [spootnik/unilog "0.7.24"]]}})
+                                  [spootnik/unilog "0.7.25"]]}})


### PR DESCRIPTION
Make all library version latest.

Only [this braking change](https://github.com/cognitect-labs/aws-api/blob/master/UPGRADE.md) is included but it may affect few cases.
