### PR TITLE
Add consume limit option

### DIFF
--- a/src/gluttony/core.clj
+++ b/src/gluttony/core.clj
@@ -49,6 +49,11 @@
                                  default: 20 * num-receivers
     :receive-limit             - the number of messages to receive at a time. 1 to 10.
                                  default: 10
+    :consume-limit             - the number of processing messages at the same time. 0 to 1024
+                                 If the consume run asynchronously, for instance inside go block,
+                                 you may want to use this option.
+                                 default: 0, which means gluttony doesn't care about how many message
+                                 are processed simultaneously.
     :long-polling-duration     - the duration (in seconds) for which the call waits for a message to
                                  arrive in the queue before returning. 0 to 20.
                                  default: 20
@@ -81,6 +86,8 @@
                                  (* 20 num-receivers))
         receive-limit (or (:receive-limit opts)
                           10)
+        consume-limit (or (:consume-limit opts)
+                          0)
         long-polling-duration (or (:long-polling-duration opts)
                                   20)
         exceptional-poll-delay-ms (or (:exceptional-poll-delay-ms opts)
@@ -93,6 +100,7 @@
                                   :num-receivers num-receivers
                                   :message-channel-size message-channel-size
                                   :receive-limit receive-limit
+                                  :consume-limit consume-limit
                                   :long-polling-duration long-polling-duration
                                   :exceptional-poll-delay-ms exceptional-poll-delay-ms
                                   :heartbeat (:heartbeat opts)

--- a/src/gluttony/record/consumer.clj
+++ b/src/gluttony/record/consumer.clj
@@ -103,14 +103,19 @@
    num-receivers
    message-channel-size
    receive-limit
+   consume-limit
    long-polling-duration
    exceptional-poll-delay-ms
    message-chan
+   consume-chan
    heartbeat
    heartbeat-timeout]
   p/IConsumer
   (-start [this]
-    (let [this (assoc this :message-chan (a/chan message-channel-size))]
+    (let [this (assoc this
+                      :message-chan (a/chan message-channel-size)
+                      :consume-chan (when (pos? consume-limit)
+                                      (a/chan consume-limit)))]
       (start-workers this)
       (start-receivers this)
       this))
@@ -129,6 +134,7 @@
                  num-receivers
                  message-channel-size
                  receive-limit
+                 consume-limit
                  long-polling-duration
                  exceptional-poll-delay-ms
                  heartbeat
@@ -141,6 +147,7 @@
          (pos? num-receivers)
          (pos? message-channel-size)
          (<= 1 receive-limit 10)
+         (<= 0 consume-limit 1024)
          (<= 0 long-polling-duration 20)
          (pos? exceptional-poll-delay-ms)
          (or (= nil heartbeat heartbeat-timeout)

--- a/test/gluttony/core_test.clj
+++ b/test/gluttony/core_test.clj
@@ -188,7 +188,7 @@
                                         :num-receivers 1
                                         :long-polling-duration 10
                                         :consume-limit 1})]
-          (a/<!! (th/wait-chan (* 1000 45) (fn [] (>= (count @collected) 2))))
+          (a/<!! (th/wait-chan (* 1000 45) (fn [] (>= (count @collected) 6))))
           (is (= (set (range 1 4))
                  (set (keep-indexed (fn [i v]
                                       (when (even? i)

--- a/test/gluttony/core_test.clj
+++ b/test/gluttony/core_test.clj
@@ -32,8 +32,10 @@
               :num-receivers (max 1 (int (/ num-workers 10)))
               :message-channel-size (* 20 (max 1 (int (/ num-workers 10))))
               :receive-limit 10
+              :consume-limit 0
               :long-polling-duration 20
               :exceptional-poll-delay-ms 10000
+              :consume-chan nil
               :heartbeat nil
               :heartbeat-timeout nil}
              (dissoc consumer :message-chan)))
@@ -47,6 +49,7 @@
                                     :num-receivers 1
                                     :message-channel-size 10
                                     :receive-limit 5
+                                    :consume-limit 10
                                     :heartbeat 60
                                     :heartbeat-timeout 300})]
       (is (instance? Consumer consumer))
@@ -58,11 +61,12 @@
               :num-receivers 1
               :message-channel-size 10
               :receive-limit 5
+              :consume-limit 10
               :long-polling-duration 20
               :exceptional-poll-delay-ms 10000
               :heartbeat 60
               :heartbeat-timeout 300}
-             (dissoc consumer :message-chan)))
+             (dissoc consumer :message-chan :consume-chan)))
       (stop-consumer consumer))))
 
 (deftest verify-work-of-receiver-and-worker

--- a/test/gluttony/record/consumer_test.clj
+++ b/test/gluttony/record/consumer_test.clj
@@ -17,6 +17,7 @@
                                 :num-receivers 1
                                 :message-channel-size 10
                                 :receive-limit 10
+                                :consume-limit 0
                                 :long-polling-duration 10
                                 :exceptional-poll-delay-ms 1000}))
         "queue-url must not be blank")
@@ -28,7 +29,8 @@
                                 :num-workers 1
                                 :num-receivers 1
                                 :message-channel-size 10
-                                :receive-limit 10
+                                :receive-limit 1
+                                :consume-limit 0
                                 :long-polling-duration 10
                                 :exceptional-poll-delay-ms 1000}))
         "consume must be a function")
@@ -41,6 +43,7 @@
                                 :num-receivers 1
                                 :message-channel-size 10
                                 :receive-limit 10
+                                :consume-limit 0
                                 :long-polling-duration 10
                                 :exceptional-poll-delay-ms 1000}))
         "client must be a instance of cognitect.aws.client.Clinet")
@@ -53,6 +56,7 @@
                                 :num-receivers 1
                                 :message-channel-size 10
                                 :receive-limit 10
+                                :consume-limit 0
                                 :long-polling-duration 10
                                 :exceptional-poll-delay-ms 1000}))
         "given-client? must be a boolean value")
@@ -65,6 +69,7 @@
                                 :num-receivers 1
                                 :message-channel-size 10
                                 :receive-limit 10
+                                :consume-limit 0
                                 :long-polling-duration 10
                                 :exceptional-poll-delay-ms 1000}))
         "num-workers must be a positive value")
@@ -77,6 +82,7 @@
                                 :num-receivers 0
                                 :message-channel-size 10
                                 :receive-limit 10
+                                :consume-limit 0
                                 :long-polling-duration 10
                                 :exceptional-poll-delay-ms 1000}))
         "num-receivers must be a positive value")
@@ -89,6 +95,7 @@
                                 :num-receivers 1
                                 :message-channel-size 0
                                 :receive-limit 10
+                                :consume-limit 0
                                 :long-polling-duration 10
                                 :exceptional-poll-delay-ms 1000}))
         "message-channel-size must be a positive value")
@@ -101,6 +108,7 @@
                                 :num-receivers 1
                                 :message-channel-size 10
                                 :receive-limit 11
+                                :consume-limit 0
                                 :long-polling-duration 10
                                 :exceptional-poll-delay-ms 1000}))
         "receive-limit must be between zero and ten")
@@ -113,6 +121,20 @@
                                 :num-receivers 1
                                 :message-channel-size 10
                                 :receive-limit 10
+                                :consume-limit 1025
+                                :long-polling-duration 10
+                                :exceptional-poll-delay-ms 1000}))
+        "consuem-limit must be between 0 and 1024")
+    (is (thrown? AssertionError
+                 (new-consumer {:queue-url "https://ap..."
+                                :consume (fn [_ _ _])
+                                :client client
+                                :given-client? true
+                                :num-workers 1
+                                :num-receivers 1
+                                :message-channel-size 10
+                                :receive-limit 10
+                                :consume-limit 0
                                 :long-polling-duration 21
                                 :exceptional-poll-delay-ms 1000}))
         "long-polling-duration must be between zero and twenty")
@@ -125,6 +147,7 @@
                                 :num-receivers 1
                                 :message-channel-size 10
                                 :receive-limit 10
+                                :consume-limit 0
                                 :long-polling-duration 20
                                 :exceptional-poll-delay-ms 0}))
         "exceptional-poll-delay-ms must be a positive value")
@@ -137,6 +160,7 @@
                                 :num-receivers 1
                                 :message-channel-size 10
                                 :receive-limit 10
+                                :consume-limit 0
                                 :long-polling-duration 20
                                 :exceptional-poll-delay-ms 0
                                 :heartbeat 60}))
@@ -150,6 +174,7 @@
                                 :num-receivers 1
                                 :message-channel-size 10
                                 :receive-limit 10
+                                :consume-limit 0
                                 :long-polling-duration 20
                                 :exceptional-poll-delay-ms 0
                                 :heartbeat 60


### PR DESCRIPTION
Add `:consume-limit` option.
It may be needed when if given `consume` function works asynchronously you would want to limit the number of running consume at the same time.
