### PR TITLE
Fix signing order

### DIFF
--- a/src/gluttony/core.clj
+++ b/src/gluttony/core.clj
@@ -66,6 +66,9 @@
                                  If it isn't set, heartbeat doesn't work.
                                  If it's set, :heartbeat-timeout is required.
                                  Refer to AWS documents for more detail: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/working-with-messages.html
+                                 If you set this option and :consume-limit, recommend to make
+                                 :consume-limit bigger than :message-channel-size so as not to block
+                                 heartbeat requests.
     :heartbeat-timeout         - the timeout (in seconds) of heartbeat.
                                  If your consume function doesn't call respond or raise within heartbeat
                                  timeout, the consumer doesn't extend message visibility any more.

--- a/src/gluttony/record/consumer.clj
+++ b/src/gluttony/record/consumer.clj
@@ -93,12 +93,11 @@
                         consume-chan]}]
   (dotimes [i num-workers]
     (a/go-loop []
+      (when consume-chan
+        ;; puts a sign which show a worker is now processing a message
+        (a/>! consume-chan :consuming))
       (when-let [message (a/<! message-chan)]
         (log/debugf "worker %s takes %s" i message)
-        (when consume-chan
-          ;; puts a sign which show a worker is now processing a message
-          (a/>! consume-chan :consuming)
-          (log/debugf "puts a sign of message-id:%s" (:message-id message)))
         (let [p (promise)
               respond (partial respond* consumer p message)
               raise (partial raise* consumer p message)]


### PR DESCRIPTION
Move consume signing to before getting a message.

If a client set `heartbeat` and `:consume-limit` and `:consume-limit` was less than `:message-channel-size`, heartbeat wouldn't work as a user expects.
Currently when a worker receives a message but can't start heatbeat for `:consume-limit` , heartbeat can't  run before visibility timeout.