### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,4 +54,7 @@ jobs:
         run: make lint
 
       - name: Test
+        env:
+          AWS_ACCESS_KEY_ID: dummy
+          AWS_SECRET_ACCESS_KEY: dummy
         run: make test


### PR DESCRIPTION
elasticmq (mock of amazon sqs) does not require credentials.
But, aws-api library requires credentials.

Pass dummy credentials via environment variable.