### PR TITLE
Do not take extra signs from consume-chan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Fixed
+* Fixed `respond` and `raise` not to take extra signs when these functions are called more than once.
 
 ## 0.4.87
 ### Changed

--- a/test/gluttony/core_test.clj
+++ b/test/gluttony/core_test.clj
@@ -181,6 +181,8 @@
                           (a/<! (a/timeout 10))             ; Make a point of park
                           (swap! collected
                                  conj Integer/MIN_VALUE)
+                          (respond)
+                          ;; Respond twice on purpose
                           (respond)))
               consumer (start-consumer queue-url consume
                                        {:client th/client


### PR DESCRIPTION
When `respond` and `raise` are called more than once, gluttony will take extra signs from `consume-chan`.
This behavior leads incorrect works of `consume-limit` option.

If inner promise is already realized, gluttony should not take any signs from `consume-chan`.